### PR TITLE
Fix symbolic linking of frameworks and dsyms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Removed
 - None.
 ### Fixed
-- None.
+- Fix symbolic linking of frameworks and dsyms.
 ### Security
 - None.
 

--- a/Sources/AccioKit/Services/CarthageBuilderService.swift
+++ b/Sources/AccioKit/Services/CarthageBuilderService.swift
@@ -27,10 +27,8 @@ final class CarthageBuilderService {
             print("Linking required frameworks build products '\(requiredFrameworkProduct.frameworkDirPath)(.dSYM)' into directory '\(productsTargetDirectoryUrl.path)' ...", level: .verbose)
 
             try bash("mkdir -p '\(productsTargetDirectoryUrl.path)'")
-            let targetFrameworkUrl = productsTargetDirectoryUrl.appendingPathComponent("\(requiredFramework.libraryName).framework")
-
-            try bash("ln -f -s '\(requiredFrameworkProduct.frameworkDirPath)' '\(targetFrameworkUrl.path)'")
-            try bash("ln -f -s '\(requiredFrameworkProduct.symbolsFilePath)' '\(targetFrameworkUrl.path).dSYM'")
+            try bash("ln -f -s '\(requiredFrameworkProduct.frameworkDirPath)' '\(productsTargetDirectoryUrl.path)'")
+            try bash("ln -f -s '\(requiredFrameworkProduct.symbolsFilePath)' '\(productsTargetDirectoryUrl.path)'")
         }
 
         try XcodeProjectSchemeHandlerService.shared.removeUnnecessarySharedSchemes(from: framework, platform: platform)


### PR DESCRIPTION
The adjusted bash commands still produce the expected result.

However they fix an issue with the `ln` command when creating a symlink for `xxx.framework.dSYM` where the `ln` command failed saying `Operation not permitted`. Maybe this was a confusion with the multiple `.` characters in the file name. Not specifying this filename works around this problem in a way that doesn't change the functionality of the commands.