### PR TITLE
Pass options to Accio as comments in the Package.swift file

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,48 @@ let package = Package(
 )
 ```
 
+#### Adding custom configuration
+It is possible to add Accio comments to the `Package.swift` file. They are used for passing to Accio additional configuration that can not be specified using the official manifest format. Example:
+
+```swift
+// swift-tools-version:5.0
+import PackageDescription
+
+let package = Package(
+    name: "XcodeProjectName",
+    products: [],
+    dependencies: [
+        .package(url: "https://github.com/Flinesoft/HandySwift.git", .upToNextMajor(from: "2.8.0")),
+        .package(url: "https://github.com/Flinesoft/HandyUIKit.git", .upToNextMajor(from: "1.9.0")),
+        .package(url: "https://github.com/Flinesoft/Imperio.git", .upToNextMajor(from: "3.0.0")),
+        .package(url: "https://github.com/JamitLabs/MungoHealer.git", .upToNextMajor(from: "0.3.0")),
+        .package(url: "https://github.com/SwiftyBeaver/SwiftyBeaver.git", .upToNextMajor(from: "1.6.2")),
+    ],
+    targets: [
+        .target(
+            name: "AppTargetName",
+            dependencies: [
+              // accio product-type:static-framework
+              "HandySwift",
+              "HandyUIKit",
+              // accio integration-type:cocoapods
+              "Imperio",
+              // accio integration-type:default
+              "MungoHealer",
+              "SwiftyBeaver",
+            ],
+            path: "TestProject-iOS"
+        ),
+    ]
+)
+```
+
+In the above example:
+- All the dependencies in the `AppTargetName` are built as static frameworks.
+- `Imperio` is integrated into the Xcode project using a `Podfile`.
+- `MungoHealer` and `SwiftyBeaver` are integrated in the Xcode project following the default approach (as linked frameworks).
+
+
 ### Installing Dependencies
 
 To install the dependencies, you can use either the `install` or `update` command. The only difference is, that `install` won't update any dependency versions if they were already previously resolved. `update` will always update to the latest version within the specified range. For example:

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ let package = Package(
 In the above example:
 - All the dependencies in the `AppTargetName` are built as static frameworks.
 - `Imperio` is integrated into the Xcode project using a `Podfile`.
-- `MungoHealer` and `SwiftyBeaver` are integrated in the Xcode project following the default approach (as linked frameworks).
+- `HandySwift`, `HandyUIKit`, `MungoHealer` and `SwiftyBeaver` are integrated in the Xcode project following the default approach (as linked frameworks).
 
 
 ### Installing Dependencies

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ let package = Package(
 In the above example:
 - All the dependencies in the `AppTargetName` are built as static frameworks.
 - `Imperio` is integrated into the Xcode project using a `Podfile`.
-- `HandySwift`, `HandyUIKit`, `MungoHealer` and `SwiftyBeaver` are integrated in the Xcode project following the default approach (as linked frameworks).
+- `HandySwift`, `HandyUIKit`, `MungoHealer` and `SwiftyBeaver` are integrated in the Xcode project following the default approach, as compiled binaries.
 
 
 ### Installing Dependencies

--- a/Sources/AccioKit/Models/DependencyGraph.swift
+++ b/Sources/AccioKit/Models/DependencyGraph.swift
@@ -56,6 +56,7 @@ extension DependencyGraph {
             projectName: dependency.name,
             libraryName: libraryName,
             projectDirectory: dependency.path,
+            additionalConfiguration: try ManifestCommentsHandlerService.shared.additionalConfiguration(for: dependency.name),
             requiredFrameworks: try dependency.manifest().frameworkDependencies(ofLibrary: libraryName, dependencyGraph: self)
         )
     }

--- a/Sources/AccioKit/Models/Framework.swift
+++ b/Sources/AccioKit/Models/Framework.swift
@@ -62,7 +62,7 @@ struct Framework {
 
 /// The type of the product to be generated for a dependency
 enum ProductType: String, CaseIterable {
-    /// The default one: generate the product as the author of the dependency has configured it
+    /// Generate the product as the author of the dependency has configured it
     case `default`
     /// Generate a static framework
     case staticFramework = "static-framework"
@@ -72,9 +72,11 @@ enum ProductType: String, CaseIterable {
 
 /// The type of integration to be used when adding the dependencies to the Xcode project
 enum IntegrationType: String, CaseIterable {
-    /// The default one: adding the dependencies to the Xcode project
-    case `default`
-    /// Adding the dependencies to a cocoapods setup
+    /// Adding the dependencies to the Xcode project as already compiled binaries (the option by default)
+    case binary = "default"
+    /// Adding the dependencies to the Xcode project as source code
+    case source
+    /// Adding the dependencies to a cocoapods setup (using the compiled binaries, not source code)
     case cocoapods
 }
 
@@ -83,6 +85,6 @@ struct AdditionalConfiguration: Equatable {
     var productType: ProductType
     var integrationType: IntegrationType
 
-    static let `default` = AdditionalConfiguration(productType: .default, integrationType: .default)
+    static let `default` = AdditionalConfiguration(productType: .default, integrationType: .binary)
 }
 

--- a/Sources/AccioKit/Models/Framework.swift
+++ b/Sources/AccioKit/Models/Framework.swift
@@ -79,7 +79,7 @@ enum IntegrationType: String, CaseIterable {
 }
 
 /// Additional configuration for the frameworks
-struct AdditionalConfiguration {
+struct AdditionalConfiguration: Equatable {
     var productType: ProductType
     var integrationType: IntegrationType
 

--- a/Sources/AccioKit/Models/Framework.swift
+++ b/Sources/AccioKit/Models/Framework.swift
@@ -9,6 +9,7 @@ struct Framework {
     let projectName: String
     let libraryName: String
     let projectDirectory: String
+    let additionalConfiguration: AdditionalConfiguration
     let requiredFrameworks: [Framework]
 
     var commitHash: String {
@@ -58,3 +59,30 @@ struct Framework {
         return path.hasSuffix(".xcodeproj") || path.hasSuffix(".xcworkspace")
     }
 }
+
+/// The type of the product to be generated for a dependency
+enum ProductType: String, CaseIterable {
+    /// The default one: generate the product as the author of the dependency has configured it
+    case `default`
+    /// Generate a static framework
+    case staticFramework = "static-framework"
+    /// Generate a dynamic framework
+    case dynamicFramework = "dynamic-framework"
+}
+
+/// The type of integration to be used when adding the dependencies to the Xcode project
+enum IntegrationType: String, CaseIterable {
+    /// The default one: adding the dependencies to the Xcode project
+    case `default`
+    /// Adding the dependencies to a cocoapods setup
+    case cocoapods
+}
+
+/// Additional configuration for the frameworks
+struct AdditionalConfiguration {
+    var productType: ProductType
+    var integrationType: IntegrationType
+
+    static let `default` = AdditionalConfiguration(productType: .default, integrationType: .default)
+}
+

--- a/Sources/AccioKit/Services/ManifestCommentsHandlerService.swift
+++ b/Sources/AccioKit/Services/ManifestCommentsHandlerService.swift
@@ -76,8 +76,8 @@ final class ManifestCommentsHandlerService {
         let matches = packageManifestContent.nestedMatches(for: Regex.accioComment)
         let comments: [RawComment] = matches.map {
             var lines = $0.lines()
-            let firstLine = lines.removeFirst()
-            return RawComment(header: firstLine.trimmingCharacters(in: .whitespaces), content: lines.joined(separator: "\n"))
+            let firstLine = lines.removeFirst().trimmingCharacters(in: .whitespaces)
+            return RawComment(header: firstLine, content: lines.joined(separator: "\n"))
         }
 
         return try comments.flatMap { comment -> [ManifestComment] in

--- a/Sources/AccioKit/Services/ManifestCommentsHandlerService.swift
+++ b/Sources/AccioKit/Services/ManifestCommentsHandlerService.swift
@@ -1,0 +1,179 @@
+import Foundation
+import SwiftShell
+
+/// Possible errors thrown by the ManifestCommentsHandlerService
+enum ManifestCommentsHandlerError: Error {
+    case sameKeyAppearsMoreThanOnceInTheSameComment(count: Int)
+    case keyWithoutValue(key: CommentKey)
+    case invalidValue(key: CommentKey, value: String, possibleValues: [String])
+    case commentWithoutKnownKeys(comment: String, possibleKeys: [String])
+}
+
+/// A service that handles all logic related with parsing all the information from the manifest that is passed as accio comments
+final class ManifestCommentsHandlerService {
+    static let shared = ManifestCommentsHandlerService(workingDirectory: GlobalOptions.workingDirectory.value ?? FileManager.default.currentDirectoryPath)
+    /// Pattern to detect an accio comment
+    static let accioPattern = #"(.*)//\s*accio"#
+    /// Capture all text that follows the same level of indentation
+    static let sameIndentationPattern = #"(\n\1.*)*"#
+    /// Swift string regex. From: https://stackoverflow.com/questions/171480/regex-grabbing-values-between-quotation-marks
+    static let swiftStringRegex = NSRegularExpression(#"(["'])(?:(?=(\\?))\2.)*?\1"#)
+    /// Regex matching all text that starts with an accio comment and has the same indentation level
+    static let commentRegex = NSRegularExpression("\(accioPattern).*\(sameIndentationPattern)")
+
+    private let workingDirectory: URL
+
+    init(workingDirectory: String) {
+        self.workingDirectory = URL(fileURLWithPath: workingDirectory)
+    }
+
+    /// Returns all the information from the manifest that is passed as accio comments
+    func loadManifestComments() throws -> [ManifestComment] {
+        let packageManifestPath = workingDirectory.appendingPathComponent("Package.swift")
+        let packageManifestContent = try String(contentsOf: packageManifestPath)
+        let matches = packageManifestContent.matches(for: ManifestCommentsHandlerService.commentRegex)
+        let comments: [RawComment] = matches.map {
+            var lines = $0.lines()
+            let firstLine = lines.removeFirst()
+            return RawComment(header: firstLine, content: lines.joined(separator: "\n"))
+        }
+
+        return try comments.flatMap { comment -> [ManifestComment] in
+            return try parse(comment: comment)
+        }
+    }
+
+    /// Parses a raw comment, returning the information that it contains
+    private func parse(comment: RawComment) throws -> [ManifestComment] {
+        let results: [ManifestComment] = try CommentKey.allCases.compactMap { commentKey in
+            let regex = NSRegularExpression(commentKey.rawValue)
+            if comment.header.matches(regex) {
+                return try commentKey.parse(comment)
+            } else {
+                // Do nothing
+                return nil
+            }
+        }
+        guard !results.isEmpty else {
+            throw ManifestCommentsHandlerError.commentWithoutKnownKeys(
+                comment: comment.header,
+                possibleKeys: CommentKey.allCases.map { $0.rawValue }
+            )
+        }
+
+        return results
+    }
+}
+
+/// A raw comment
+struct RawComment {
+    let header: String
+    let content: String
+}
+
+/// The possible comment keys accepted in the manifest
+enum CommentKey: String, CaseIterable {
+    case productType = "product-type"
+    case integrationType = "integration-type"
+
+    /// The pattern used to identify key and value
+    var pattern: String {
+        return "\(self.rawValue)" + #":[^\s]+"#
+    }
+
+    /// Parses the comment, extracting all the information associated with a key
+    func parse(_ comment: RawComment) throws -> ManifestComment {
+        guard let value = try getValue(from: comment.header) else {
+            throw ManifestCommentsHandlerError.keyWithoutValue(key: self)
+        }
+
+        switch self {
+        case .productType:
+            guard let productType = ProductType(rawValue: value) else {
+                throw ManifestCommentsHandlerError.invalidValue(key: self, value: value, possibleValues: ProductType.allCases.map { $0.rawValue })
+            }
+
+            let dependencies = comment.content.matches(for: ManifestCommentsHandlerService.swiftStringRegex)
+            return ManifestComment.productType(productType: productType, dependencies: dependencies)
+
+        case .integrationType:
+            guard let integrationType = IntegrationType(rawValue: value) else {
+                throw ManifestCommentsHandlerError.invalidValue(key: self, value: value, possibleValues: IntegrationType.allCases.map { $0.rawValue })
+            }
+
+            let dependencies = comment.content.matches(for: ManifestCommentsHandlerService.swiftStringRegex)
+            return ManifestComment.integrationType(integrationType: integrationType, dependencies: dependencies)
+        }
+    }
+
+    /// Extracts the value for a key from the string
+    private func getValue(from string: String) throws -> String? {
+        let regex = NSRegularExpression(pattern)
+        let matches = string.matches(for: regex)
+        guard let match = matches.first else {
+            // The accio comment does not include the comment key
+            return nil
+        }
+
+        guard matches.count == 1 else {
+            throw ManifestCommentsHandlerError.sameKeyAppearsMoreThanOnceInTheSameComment(count: matches.count)
+        }
+
+        let value = match.components(separatedBy: ":")[1]
+        return value
+    }
+}
+
+/// The configuration in the manifest that is passed as comments
+enum ManifestComment {
+    /// Product type to be used when generating the dependency products
+    case productType(productType: ProductType, dependencies: [String])
+    /// Integration type to be used when integrating the dependencies in the Xcode project
+    case integrationType(integrationType: IntegrationType, dependencies: [String])
+}
+
+/// The type of the product to be generated for a dependency
+enum ProductType: String, CaseIterable {
+    /// The default one: generate the product as the author of the dependency has configured it
+    case `default`
+    /// Generate a static framework
+    case staticFramework = "static-framework"
+    /// Generate a dynamic framework
+    case dynamicFramework = "dynamic-framework"
+}
+
+/// The type of integration to be used when adding the dependencies to the Xcode project
+enum IntegrationType: String, CaseIterable {
+    /// The default one: adding the dependencies to the Xcode project
+    case `default`
+    /// Adding the dependencies to a cocoapods setup
+    case cocoapods
+}
+
+/// MARK: helper extension to match strings with regular expressions
+
+private extension String {
+    /// Get all matches of the regex from the string
+    func matches(for regex: NSRegularExpression) -> [String] {
+        let results = regex.matches(in: self, range: NSRange(self.startIndex..., in: self))
+        return results.map {
+            String(self[Range($0.range, in: self)!])
+        }
+    }
+
+    /// Tells is the string matches the regex
+    func matches(_ regex: NSRegularExpression) -> Bool {
+        let results = regex.matches(in: self, range: NSRange(self.startIndex..., in: self))
+        return !results.isEmpty
+    }
+}
+
+extension NSRegularExpression {
+    convenience init(_ pattern: String) {
+        do {
+            try self.init(pattern: pattern, options: [.caseInsensitive])
+        } catch {
+            preconditionFailure("Illegal regular expression: \(pattern).")
+        }
+    }
+}

--- a/Tests/AccioKitTests/Services/FrameworkCachingServiceTests.swift
+++ b/Tests/AccioKitTests/Services/FrameworkCachingServiceTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class FrameworkCachingServiceTests: XCTestCase {
     private let sharedCachePath: String = FileManager.userCacheDirUrl.appendingPathComponent("AccioTestSharedCache").path
 
-    private let testFramework = Framework(projectName: "TestProject", libraryName: "Example", projectDirectory: "", requiredFrameworks: [])
+    private let testFramework = Framework(projectName: "TestProject", libraryName: "Example", projectDirectory: "", additionalConfiguration: .default, requiredFrameworks: [])
     private let testFrameworkProduct = FrameworkProduct(
         frameworkDirPath: FileManager.userCacheDirUrl.appendingPathComponent("AccioTestFrameworks/Example.framework").path,
         symbolsFilePath: FileManager.userCacheDirUrl.appendingPathComponent("AccioTestFrameworks/Example.framework.dSYM").path

--- a/Tests/AccioKitTests/Services/InstallationTypeDetectorServiceTests.swift
+++ b/Tests/AccioKitTests/Services/InstallationTypeDetectorServiceTests.swift
@@ -65,7 +65,7 @@ class InstallationTypeDetectorServiceTests: XCTestCase {
             let frameworkDirName = try! FileManager.default.contentsOfDirectory(atPath: checkoutsDir.path).first { $0.hasPrefix(frameworkName) }!
             let frameworkDir = checkoutsDir.appendingPathComponent(frameworkDirName)
 
-            let framework = Framework(projectName: "TestProject", libraryName: frameworkName, projectDirectory: frameworkDir.path, requiredFrameworks: [])
+            let framework = Framework(projectName: "TestProject", libraryName: frameworkName, projectDirectory: frameworkDir.path, additionalConfiguration: .default, requiredFrameworks: [])
 
             let installationType = try! InstallationTypeDetectorService.shared.detectInstallationType(for: framework)
             XCTAssertEqual(installationType, expectedInstallationType, "Expected \(frameworkName) to be of type \(expectedInstallationType).")

--- a/Tests/AccioKitTests/Services/ManifestCommentsHandlerServiceTests.swift
+++ b/Tests/AccioKitTests/Services/ManifestCommentsHandlerServiceTests.swift
@@ -1,0 +1,229 @@
+@testable import AccioKit
+import XCTest
+
+class ManifestCommentsHandlerServiceTests: XCTestCase {
+    private let testResourcesDir: URL = FileManager.userCacheDirUrl.appendingPathComponent("AccioTestResources")
+    private let possibleProductKeys = ["product-type", "integration-type"]
+    private let possibleIntegrationValues = ["default", "cocoapods"]
+    private let manifestResourceTopContent = """
+                // swift-tools-version:4.2
+                import PackageDescription
+
+                let package = Package(
+                    name: "TestProject",
+                    products: [],
+                    dependencies: [
+                        .package(url: "https://github.com/Flinesoft/HandySwift.git", .upToNextMajor(from: "2.8.0")),
+                        .package(url: "https://github.com/Flinesoft/HandyUIKit.git", .upToNextMajor(from: "1.9.0")),
+                        .package(url: "https://github.com/Flinesoft/Imperio.git", .upToNextMajor(from: "3.0.0")),
+                        .package(url: "https://github.com/JamitLabs/MungoHealer.git", .upToNextMajor(from: "0.3.0")),
+                        .package(url: "https://github.com/SwiftyBeaver/SwiftyBeaver.git", .upToNextMajor(from: "1.6.2")),
+                    ],
+    """
+
+    private var manifestResourceWithoutComments: Resource {
+        return Resource(
+            url: testResourcesDir.appendingPathComponent("Package.swift"),
+            contents: """
+                \(manifestResourceTopContent)
+                    targets: [
+                        .target(
+                            name: "TestProject-iOS",
+                            dependencies: [
+                              "HandySwift",
+                              "HandyUIKit",
+                              "Imperio",
+                              "MungoHealer",
+                              "SwiftyBeaver",
+                            ],
+                            path: "TestProject-iOS"
+                        )
+                    ]
+                )
+
+                """
+        )
+    }
+
+    private var manifestResourceWithEmptyComment: Resource {
+        return Resource(
+            url: testResourcesDir.appendingPathComponent("Package.swift"),
+            contents: """
+                \(manifestResourceTopContent)
+                    targets: [
+                        .target(
+                            name: "TestProject-iOS",
+                            dependencies: [
+                              "HandySwift",
+                              "HandyUIKit",
+                              "Imperio",
+                              // accio
+                              "MungoHealer",
+                              "SwiftyBeaver",
+                            ],
+                            path: "TestProject-iOS"
+                        )
+                    ]
+                )
+
+                """
+        )
+    }
+
+    private var manifestResourceWithUnknownKey: Resource {
+        return Resource(
+            url: testResourcesDir.appendingPathComponent("Package.swift"),
+            contents: """
+                \(manifestResourceTopContent)
+                    targets: [
+                        .target(
+                            name: "TestProject-iOS",
+                            dependencies: [
+                              "HandySwift",
+                              "HandyUIKit",
+                              "Imperio",
+                              // accio unknown-key
+                              "MungoHealer",
+                              "SwiftyBeaver",
+                            ],
+                            path: "TestProject-iOS"
+                        )
+                    ]
+                )
+
+                """
+        )
+    }
+
+    private var manifestResourceWithInvalidValue: Resource {
+        return Resource(
+            url: testResourcesDir.appendingPathComponent("Package.swift"),
+            contents: """
+                \(manifestResourceTopContent)
+                    targets: [
+                        .target(
+                            name: "TestProject-iOS",
+                            dependencies: [
+                              "HandySwift",
+                              "HandyUIKit",
+                              "Imperio",
+                              // accio integration-type:invalid-value
+                              "MungoHealer",
+                              "SwiftyBeaver",
+                            ],
+                            path: "TestProject-iOS"
+                        )
+                    ]
+                )
+
+                """
+        )
+    }
+
+    private var manifestResourceWithValidComments: Resource {
+        return Resource(
+            url: testResourcesDir.appendingPathComponent("Package.swift"),
+            contents: """
+                \(manifestResourceTopContent)
+                    targets: [
+                        .target(
+                            name: "TestProject-iOS",
+                            dependencies: [
+                              // accio product-type:static-framework
+                              "HandySwift",
+                              "HandyUIKit",
+                              // accio integration-type:cocoapods
+                              "Imperio",
+                              // accio integration-type:default
+                              "MungoHealer",
+                              "SwiftyBeaver",
+                            ],
+                            path: "TestProject-iOS"
+                        )
+                    ]
+                )
+
+                """
+        )
+    }
+
+    override func setUp() {
+        super.setUp()
+
+        try! bash("rm -rf '\(testResourcesDir.path)'")
+        try! bash("mkdir '\(testResourcesDir.path)'")
+    }
+
+    func testWithoutComments() {
+        resourcesLoaded([manifestResourceWithoutComments]) {
+            let manifestComments = try! ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).loadManifestComments()
+            XCTAssertEqual(manifestComments, [])
+        }
+    }
+
+    func testWithEmptyComment() {
+        resourcesLoaded([manifestResourceWithEmptyComment]) {
+            let expectedError = ManifestCommentsHandlerError.commentWithoutKnownKeys(
+                comment: "              // accio",
+                possibleKeys: possibleProductKeys
+            )
+            do {
+                _ = try ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).loadManifestComments()
+                XCTFail("Function was expected to throw")
+            } catch {
+                XCTAssertEqual(error as? ManifestCommentsHandlerError, expectedError)
+            }
+        }
+    }
+
+    func testWithUnknownKey() {
+        resourcesLoaded([manifestResourceWithUnknownKey]) {
+            let expectedError = ManifestCommentsHandlerError.commentWithoutKnownKeys(
+                comment: "              // accio unknown-key",
+                possibleKeys: possibleProductKeys
+            )
+            do {
+                _ = try ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).loadManifestComments()
+                XCTFail("Function was expected to throw")
+            } catch {
+                XCTAssertEqual(error as? ManifestCommentsHandlerError, expectedError)
+            }
+        }
+    }
+
+    func testWithInvalidValue() {
+        resourcesLoaded([manifestResourceWithInvalidValue]) {
+            let expectedError = ManifestCommentsHandlerError.invalidValue(
+                key: .integrationType,
+                value: "invalid-value",
+                possibleValues: possibleIntegrationValues
+            )
+            do {
+                _ = try ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).loadManifestComments()
+                XCTFail("Function was expected to throw")
+            } catch {
+                XCTAssertEqual(error as? ManifestCommentsHandlerError, expectedError)
+            }
+        }
+    }
+
+    func testValidComments() {
+        resourcesLoaded([manifestResourceWithValidComments]) {
+            let manifestComments = try! ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).loadManifestComments()
+            XCTAssertEqual(manifestComments, [
+                ManifestComment.productType(
+                    productType: .staticFramework,
+                    dependencies: ["HandySwift", "HandyUIKit", "Imperio", "MungoHealer", "SwiftyBeaver"]
+                ),
+                ManifestComment.integrationType(
+                    integrationType: .cocoapods,
+                    dependencies: ["Imperio", "MungoHealer", "SwiftyBeaver"]
+                ),
+                ManifestComment.integrationType(
+                    integrationType: .default,
+                    dependencies: ["MungoHealer", "SwiftyBeaver"]
+                ),
+            ])
+        }
+    }
+}

--- a/Tests/AccioKitTests/Services/ManifestCommentsHandlerServiceTests.swift
+++ b/Tests/AccioKitTests/Services/ManifestCommentsHandlerServiceTests.swift
@@ -156,8 +156,15 @@ class ManifestCommentsHandlerServiceTests: XCTestCase {
 
     func testWithoutComments() {
         resourcesLoaded([manifestResourceWithoutComments]) {
-            let manifestComments = try! ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).manifestComments()
+            let sut = ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path)
+            let manifestComments = try! sut.manifestComments()
             XCTAssertEqual(manifestComments, [])
+
+            XCTAssertEqual(try! sut.additionalConfiguration(for: "HandySwift"), .default)
+            XCTAssertEqual(try! sut.additionalConfiguration(for: "HandyUIKit"), .default)
+            XCTAssertEqual(try! sut.additionalConfiguration(for: "Imperio"), .default)
+            XCTAssertEqual(try! sut.additionalConfiguration(for: "MungoHealer"), .default)
+            XCTAssertEqual(try! sut.additionalConfiguration(for: "SwiftyBeaver"), .default)
         }
     }
 
@@ -209,7 +216,9 @@ class ManifestCommentsHandlerServiceTests: XCTestCase {
 
     func testValidComments() {
         resourcesLoaded([manifestResourceWithValidComments]) {
-            let manifestComments = try! ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).manifestComments()
+            let sut = ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path)
+            let manifestComments = try! sut.manifestComments()
+            
             XCTAssertEqual(manifestComments, [
                 ManifestComment.productType(
                     productType: .staticFramework,
@@ -224,6 +233,12 @@ class ManifestCommentsHandlerServiceTests: XCTestCase {
                     dependencies: ["MungoHealer", "SwiftyBeaver"]
                 ),
             ])
+
+            XCTAssertEqual(try! sut.additionalConfiguration(for: "HandySwift"), AdditionalConfiguration(productType: .staticFramework, integrationType: .default))
+            XCTAssertEqual(try! sut.additionalConfiguration(for: "HandyUIKit"), AdditionalConfiguration(productType: .staticFramework, integrationType: .default))
+            XCTAssertEqual(try! sut.additionalConfiguration(for: "Imperio"), AdditionalConfiguration(productType: .staticFramework, integrationType: .cocoapods))
+            XCTAssertEqual(try! sut.additionalConfiguration(for: "MungoHealer"), AdditionalConfiguration(productType: .staticFramework, integrationType: .default))
+            XCTAssertEqual(try! sut.additionalConfiguration(for: "SwiftyBeaver"), AdditionalConfiguration(productType: .staticFramework, integrationType: .default))
         }
     }
 }

--- a/Tests/AccioKitTests/Services/ManifestCommentsHandlerServiceTests.swift
+++ b/Tests/AccioKitTests/Services/ManifestCommentsHandlerServiceTests.swift
@@ -156,7 +156,7 @@ class ManifestCommentsHandlerServiceTests: XCTestCase {
 
     func testWithoutComments() {
         resourcesLoaded([manifestResourceWithoutComments]) {
-            let manifestComments = try! ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).loadManifestComments()
+            let manifestComments = try! ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).manifestComments()
             XCTAssertEqual(manifestComments, [])
         }
     }
@@ -168,7 +168,7 @@ class ManifestCommentsHandlerServiceTests: XCTestCase {
                 possibleKeys: possibleProductKeys
             )
             do {
-                _ = try ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).loadManifestComments()
+                _ = try ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).manifestComments()
                 XCTFail("Function was expected to throw")
             } catch {
                 XCTAssertEqual(error as? ManifestCommentsHandlerError, expectedError)
@@ -183,7 +183,7 @@ class ManifestCommentsHandlerServiceTests: XCTestCase {
                 possibleKeys: possibleProductKeys
             )
             do {
-                _ = try ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).loadManifestComments()
+                _ = try ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).manifestComments()
                 XCTFail("Function was expected to throw")
             } catch {
                 XCTAssertEqual(error as? ManifestCommentsHandlerError, expectedError)
@@ -199,7 +199,7 @@ class ManifestCommentsHandlerServiceTests: XCTestCase {
                 possibleValues: possibleIntegrationValues
             )
             do {
-                _ = try ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).loadManifestComments()
+                _ = try ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).manifestComments()
                 XCTFail("Function was expected to throw")
             } catch {
                 XCTAssertEqual(error as? ManifestCommentsHandlerError, expectedError)
@@ -209,7 +209,7 @@ class ManifestCommentsHandlerServiceTests: XCTestCase {
 
     func testValidComments() {
         resourcesLoaded([manifestResourceWithValidComments]) {
-            let manifestComments = try! ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).loadManifestComments()
+            let manifestComments = try! ManifestCommentsHandlerService(workingDirectory: testResourcesDir.path).manifestComments()
             XCTAssertEqual(manifestComments, [
                 ManifestComment.productType(
                     productType: .staticFramework,

--- a/Tests/AccioKitTests/Services/ManifestCommentsHandlerServiceTests.swift
+++ b/Tests/AccioKitTests/Services/ManifestCommentsHandlerServiceTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class ManifestCommentsHandlerServiceTests: XCTestCase {
     private let testResourcesDir: URL = FileManager.userCacheDirUrl.appendingPathComponent("AccioTestResources")
     private let possibleProductKeys = ["product-type", "integration-type"]
-    private let possibleIntegrationValues = ["default", "cocoapods"]
+    private let possibleIntegrationValues = ["default", "source", "cocoapods"]
     private let manifestResourceTopContent = """
                 // swift-tools-version:4.2
                 import PackageDescription
@@ -270,16 +270,16 @@ class ManifestCommentsHandlerServiceTests: XCTestCase {
                     dependencies: ["Imperio", "MungoHealer", "SwiftyBeaver"]
                 ),
                 ManifestComment.integrationType(
-                    integrationType: .default,
+                    integrationType: .binary,
                     dependencies: ["MungoHealer", "SwiftyBeaver"]
                 ),
             ])
 
-            XCTAssertEqual(try! sut.additionalConfiguration(for: "HandySwift"), AdditionalConfiguration(productType: .staticFramework, integrationType: .default))
-            XCTAssertEqual(try! sut.additionalConfiguration(for: "HandyUIKit"), AdditionalConfiguration(productType: .staticFramework, integrationType: .default))
+            XCTAssertEqual(try! sut.additionalConfiguration(for: "HandySwift"), AdditionalConfiguration(productType: .staticFramework, integrationType: .binary))
+            XCTAssertEqual(try! sut.additionalConfiguration(for: "HandyUIKit"), AdditionalConfiguration(productType: .staticFramework, integrationType: .binary))
             XCTAssertEqual(try! sut.additionalConfiguration(for: "Imperio"), AdditionalConfiguration(productType: .staticFramework, integrationType: .cocoapods))
-            XCTAssertEqual(try! sut.additionalConfiguration(for: "MungoHealer"), AdditionalConfiguration(productType: .staticFramework, integrationType: .default))
-            XCTAssertEqual(try! sut.additionalConfiguration(for: "SwiftyBeaver"), AdditionalConfiguration(productType: .staticFramework, integrationType: .default))
+            XCTAssertEqual(try! sut.additionalConfiguration(for: "MungoHealer"), AdditionalConfiguration(productType: .staticFramework, integrationType: .binary))
+            XCTAssertEqual(try! sut.additionalConfiguration(for: "SwiftyBeaver"), AdditionalConfiguration(productType: .staticFramework, integrationType: .binary))
         }
     }
 }

--- a/Tests/AccioKitTests/Services/XcodeProjectGeneratorServiceTests.swift
+++ b/Tests/AccioKitTests/Services/XcodeProjectGeneratorServiceTests.swift
@@ -34,7 +34,7 @@ class XcodeProjectGeneratorServiceTests: XCTestCase {
 
     func testPlatformToVersionWithSingleLineCommentedStringSpecifiers() {
         let projectGeneratorService = XcodeProjectGeneratorService()
-        let framework = Framework(projectName: "X", libraryName: "X", projectDirectory: testResourcesDir.path, requiredFrameworks: [])
+        let framework = Framework(projectName: "X", libraryName: "X", projectDirectory: testResourcesDir.path, additionalConfiguration: .default, requiredFrameworks: [])
 
         resourcesLoaded([singleLineCommentedManifestResourceWithStringSpecifiers]) {
             let platformToVersion: [Platform: String] = try! projectGeneratorService.platformToVersion(framework: framework)
@@ -48,7 +48,7 @@ class XcodeProjectGeneratorServiceTests: XCTestCase {
 
     func testPlatformToVersionWithMultiLineEnumCaseSpecifiers() {
         let projectGeneratorService = XcodeProjectGeneratorService()
-        let framework = Framework(projectName: "X", libraryName: "X", projectDirectory: testResourcesDir.path, requiredFrameworks: [])
+        let framework = Framework(projectName: "X", libraryName: "X", projectDirectory: testResourcesDir.path, additionalConfiguration: .default, requiredFrameworks: [])
 
         resourcesLoaded([multilineManifestResourceWithEnumCaseSpecifiers]) {
             let platformToVersion: [Platform: String] = try! projectGeneratorService.platformToVersion(framework: framework)


### PR DESCRIPTION
This is a working and tested implementation that solves https://github.com/JamitLabs/Accio/issues/54.

It is using comments in the `Package.swift` file to pass additional configuration to Accio. I added the following keys for now:
- `product-type`: `default`, `static-framework` or `dynamic-framework`.
- `integration-type`: `default` (binary), `source` (similar to https://github.com/Carthage/Carthage#using-submodules-for-dependencies) or `cocoapods`.

This PR includes parsing those options and adding them to the `Framework` object. It does not include the implementation for building static frameworks, neither the implementation of the `source` or `cocoapods` integration options.

Example:
```swift
// swift-tools-version:5.0
import PackageDescription

let package = Package(
    name: "XcodeProjectName",
    products: [],
    dependencies: [
        .package(url: "https://github.com/Flinesoft/HandySwift.git", .upToNextMajor(from: "2.8.0")),
        .package(url: "https://github.com/Flinesoft/HandyUIKit.git", .upToNextMajor(from: "1.9.0")),
        .package(url: "https://github.com/Flinesoft/Imperio.git", .upToNextMajor(from: "3.0.0")),
        .package(url: "https://github.com/JamitLabs/MungoHealer.git", .upToNextMajor(from: "0.3.0")),
        .package(url: "https://github.com/SwiftyBeaver/SwiftyBeaver.git", .upToNextMajor(from: "1.6.2")),
    ],
    targets: [
        .target(
            name: "AppTargetName",
            dependencies: [
              // accio product-type:static-framework
              "HandySwift",
              "HandyUIKit",
              // accio integration-type:cocoapods
              "Imperio",
              // accio integration-type:default
              "MungoHealer",
              "SwiftyBeaver",
            ],
            path: "TestProject-iOS"
        ),
    ]
)
```

For more information about how this works, have a look at the `README.md` file, or at the `testValidComments()` function in the `ManifestCommentsHandlerServiceTests.swift` file.