### PR TITLE
Improve warning about missing schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
   Issue: [#27](https://github.com/JamitLabs/Accio/issues/27) | PR: [#40](https://github.com/JamitLabs/Accio/pull/40) | Author: [Frederick Pietschmann](https://github.com/fredpi)
 - Avoid misleading output when building via Carthage.  
   Issue: [#56](https://github.com/JamitLabs/Accio/issues/56) | PR: [#57](https://github.com/JamitLabs/Accio/pull/57) | Author: [Frederick Pietschmann](https://github.com/fredpi)
+- Warn properly when no schemes can be found.  
+  PR: [#59](https://github.com/JamitLabs/Accio/pull/59) | Author: [Frederick Pietschmann](https://github.com/fredpi)
+
 ### Security
 - None.
 

--- a/Sources/AccioKit/Services/XcodeProjectSchemeHandlerService.swift
+++ b/Sources/AccioKit/Services/XcodeProjectSchemeHandlerService.swift
@@ -28,6 +28,7 @@ final class XcodeProjectSchemeHandlerService {
 
         guard !librarySchemePaths.isEmpty else {
             print("No shared scheme(s) found; still resuming build.", level: .warning)
+            return
         }
 
         if !matchingSchemePaths.isEmpty {

--- a/Sources/AccioKit/Services/XcodeProjectSchemeHandlerService.swift
+++ b/Sources/AccioKit/Services/XcodeProjectSchemeHandlerService.swift
@@ -26,6 +26,10 @@ final class XcodeProjectSchemeHandlerService {
         let matchingSchemePaths: [String] = librarySchemePaths.filter { expectedSchemeNames.contains($0.fileNameWithoutExtension.lowercased()) }
         let matchingSchemeNames: [String] = matchingSchemePaths.map { $0.fileNameWithoutExtension }
 
+        guard !librarySchemePaths.isEmpty else {
+            print("No shared scheme(s) found; still resuming build.", level: .warning)
+        }
+
         if !matchingSchemePaths.isEmpty {
             let schemePathsToRemove: [String] = sharedSchemePaths.filter { !matchingSchemePaths.contains($0) }
             print("Found shared scheme(s) \(matchingSchemeNames) matching specified library – removing others: \(schemePathsToRemove.map { $0.fileNameWithoutExtension })", level: .verbose)


### PR DESCRIPTION
The case covered with this code is an edge case that would have otherwise been handled a few lines below with the following text:

`
⚠️  No shared scheme(s) found matching library name 'SwiftEntryKit' – can't remove potentially unnecessary shared schemes, keeping all
`

As that text is misleading if there a no schemes at all, it's suitable to explicitly handle this case.

