### PR TITLE
Prevent checkout if no changes in resolved manifest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ cli.goAndExit()
 from the file at path `Sources/Accio/main.swift` with something like:
 
 ```swift
-cli.debugGo(with: "accio update -d /Users/You/path/to/Accio/Demo -v")
+cli.go(with: ["install", "-d", "/Users/You/path/to/Accio/Demo", "-v"])
 ```
 
 Note that the `-d` option specifies the path from within to run Accio and `-v` makes sure the logging level is set to `verbose`.

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "CryptoSwift",
+        "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "3a2acbb32ab68215ee1596ee6004da8e90c3721b",
+          "version": "1.0.0"
+        }
+      },
+      {
         "package": "HandySwift",
         "repositoryURL": "https://github.com/Flinesoft/HandySwift.git",
         "state": {
@@ -60,8 +69,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI.git",
         "state": {
           "branch": null,
-          "revision": "5318c37d3cacc8780f50b87a8840a6774320ebdf",
-          "version": "5.2.2"
+          "revision": "2f9325de7dcaa368ce5a3710b04d9df572725b14",
+          "version": "5.3.0"
         }
       },
       {
@@ -78,7 +87,7 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
           "branch": "master",
-          "revision": "50cd5c1a6c52f85d040b0ab3d3714233568ee09f",
+          "revision": "b951777f42e9acbfb8f19da623b43aaa604422f9",
           "version": null
         }
       }

--- a/Package.resolved
+++ b/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI.git",
         "state": {
           "branch": null,
-          "revision": "2f9325de7dcaa368ce5a3710b04d9df572725b14",
-          "version": "5.3.0"
+          "revision": "a777ece1f36170c53bc9b76485e7d03ff2012300",
+          "version": "5.3.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
         .library(name: "AccioKit", type: .dynamic, targets: ["AccioKit"])
     ],
     dependencies: [
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/Flinesoft/HandySwift.git", .upToNextMajor(from: "3.0.0")),
         .package(url: "https://github.com/onevcat/Rainbow.git", .upToNextMajor(from: "3.1.4")),
         .package(url: "https://github.com/jakeheis/SwiftCLI.git", .upToNextMajor(from: "5.2.2")),
@@ -24,6 +25,7 @@ let package = Package(
         .target(
             name: "AccioKit",
             dependencies: [
+                "CryptoSwift",
                 "HandySwift",
                 "Rainbow",
                 "SwiftCLI",

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
         ),
         .testTarget(
             name: "AccioKitTests",
-            dependencies: ["AccioKit", "HandySwift", "XcodeProj"]
+            dependencies: ["CryptoSwift", "AccioKit", "HandySwift", "XcodeProj"]
         )
     ]
 )

--- a/Sources/AccioKit/Commands/InstallCommand.swift
+++ b/Sources/AccioKit/Commands/InstallCommand.swift
@@ -14,6 +14,12 @@ public class InstallCommand: Command {
     // MARK: - Instance Methods
     public func execute() throws {
         let config = try Config.load()
+
+        if try attemptUncachingAllRequiredFrameworks(sharedCachePath: sharedCachePath.value ?? config.defaultSharedCachePath) {
+            print("No changes found & successfully copied dependencies from cache.", level: .info)
+            return
+        }
+
         try revertCheckoutChanges()
         try DependencyResolverService.shared.resolveDependencies()
 

--- a/Sources/AccioKit/Commands/InstallCommand.swift
+++ b/Sources/AccioKit/Commands/InstallCommand.swift
@@ -15,7 +15,7 @@ public class InstallCommand: Command {
     public func execute() throws {
         let config = try Config.load()
 
-        if try attemptUncachingAllRequiredFrameworks(sharedCachePath: sharedCachePath.value ?? config.defaultSharedCachePath) {
+        if try loadRequiredFrameworksFromCache(sharedCachePath: sharedCachePath.value ?? config.defaultSharedCachePath) {
             print("No changes found & successfully copied dependencies from cache.", level: .info)
             return
         }

--- a/Sources/AccioKit/Commands/Protocols/DependencyInstaller.swift
+++ b/Sources/AccioKit/Commands/Protocols/DependencyInstaller.swift
@@ -106,13 +106,13 @@ extension DependencyInstaller {
     ) throws -> Bool {
         let cachingService = ResolvedManifestCachingService(sharedCachePath: sharedCachePath)
 
-        guard let cachedFramworkProducts = try cachingService.cachedFrameworkProducts(
+        guard let cachedFrameworkProducts = try cachingService.cachedFrameworkProducts(
             forResolvedManifestAt: URL(fileURLWithPath: workingDirectory).appendingPathComponent("Package.resolved")
         ) else {
             return false
         }
 
-        let cachedFrameworkProductUrls: [URL] = cachedFramworkProducts.compactMap { cachedFrameworkProduct in
+        let cachedFrameworkProductUrls: [URL] = cachedFrameworkProducts.compactMap { cachedFrameworkProduct in
             let localCacheFileUrl = URL(fileURLWithPath: Constants.localCachePath).appendingPathComponent(cachedFrameworkProduct.cacheFileSubPath)
 
             if FileManager.default.fileExists(atPath: localCacheFileUrl.path) {
@@ -130,7 +130,7 @@ extension DependencyInstaller {
             return nil
         }
 
-        guard cachedFrameworkProductUrls.count == cachedFramworkProducts.count else {
+        guard cachedFrameworkProductUrls.count == cachedFrameworkProducts.count else {
             print("Not all required build products specified in resolved manifest are cached – unable to skip checkout/integration process ...")
             return false
         }

--- a/Sources/AccioKit/Commands/Protocols/DependencyInstaller.swift
+++ b/Sources/AccioKit/Commands/Protocols/DependencyInstaller.swift
@@ -9,6 +9,7 @@ protocol DependencyInstaller {
     func loadManifest() throws -> Manifest
     func revertCheckoutChanges(workingDirectory: String) throws
     func buildFrameworksAndIntegrateWithXcode(manifest: Manifest, dependencyGraph: DependencyGraph, sharedCachePath: String?) throws
+    func attemptUncachingAllRequiredFrameworks(sharedCachePath: String?) throws -> Bool
 }
 
 extension DependencyInstaller {
@@ -83,5 +84,56 @@ extension DependencyInstaller {
 
         try XcodeProjectIntegrationService.shared.handleRemovedTargets(keepingTargets: appTargets)
         try bash("rm -rf '\(Constants.temporaryFrameworksUrl.path)'")
+
+        try ResolvedManifestCachingService(sharedCachePath: sharedCachePath).cacheResolvedManifest(
+            at: URL(fileURLWithPath: "Package.resolved"),
+            with: parsingResults.flatMap {
+                $0.frameworkProducts.map {
+                    CachedFrameworkProduct(swiftVersion: Constants.swiftVersion, libraryName: $0.libraryName, commitHash: $0.commitHash, platform: $0.platformName)
+                }
+            }
+        )
+    }
+
+    func attemptUncachingAllRequiredFrameworks(sharedCachePath: String?) throws -> Bool {
+        let cachingService = ResolvedManifestCachingService(sharedCachePath: sharedCachePath)
+
+        guard let cachedFramworkProducts = try cachingService.cachedFrameworkProducts(forResolvedManifestAt: URL(fileURLWithPath: "Package.resolved")) else {
+            return false
+        }
+
+        let cachedFrameworkProductUrls: [URL] = cachedFramworkProducts.compactMap { cachedFrameworkProduct in
+            let localCacheFileUrl = URL(fileURLWithPath: Constants.localCachePath).appendingPathComponent(cachedFrameworkProduct.cacheFileSubPath)
+
+            if FileManager.default.fileExists(atPath: localCacheFileUrl.path) {
+                return localCacheFileUrl
+            }
+
+            if let sharedCachePath = sharedCachePath {
+                let sharedCacheFileUrl = URL(fileURLWithPath: sharedCachePath).appendingPathComponent(cachedFrameworkProduct.cacheFileSubPath)
+
+                if FileManager.default.fileExists(atPath: sharedCacheFileUrl.path) {
+                    return sharedCacheFileUrl
+                }
+            }
+
+            return nil
+        }
+
+        guard cachedFrameworkProductUrls.count == cachedFramworkProducts.count else {
+            print("Not all required build products specified in resolved manifest are cached – unable to skip checkout/integration process ...")
+            return false
+        }
+
+        print("Found all required build products specified in resolved manifest in cache – skipping checkout & integration process ...")
+
+        let frameworkProducts: [FrameworkProduct] = try cachedFrameworkProductUrls.map {
+            return try FrameworkCachingService(sharedCachePath: sharedCachePath).frameworkProduct(forCachedFileAt: $0)
+        }
+
+        try XcodeProjectIntegrationService.shared.clearDependenciesFolder()
+        try XcodeProjectIntegrationService.shared.copy(cachedFrameworkProducts: frameworkProducts)
+
+        return true
     }
 }

--- a/Sources/AccioKit/Commands/Protocols/DependencyInstaller.swift
+++ b/Sources/AccioKit/Commands/Protocols/DependencyInstaller.swift
@@ -9,7 +9,7 @@ protocol DependencyInstaller {
     func loadManifest() throws -> Manifest
     func revertCheckoutChanges(workingDirectory: String) throws
     func buildFrameworksAndIntegrateWithXcode(workingDirectory: String, manifest: Manifest, dependencyGraph: DependencyGraph, sharedCachePath: String?) throws
-    func attemptUncachingAllRequiredFrameworks(workingDirectory: String, sharedCachePath: String?) throws -> Bool
+    func loadRequiredFrameworksFromCache(workingDirectory: String, sharedCachePath: String?) throws -> Bool
 }
 
 extension DependencyInstaller {
@@ -100,7 +100,7 @@ extension DependencyInstaller {
         )
     }
 
-    func attemptUncachingAllRequiredFrameworks(
+    func loadRequiredFrameworksFromCache(
         workingDirectory: String = GlobalOptions.workingDirectory.value ?? FileManager.default.currentDirectoryPath,
         sharedCachePath: String?
     ) throws -> Bool {

--- a/Sources/AccioKit/Models/CachedFrameworkProduct.swift
+++ b/Sources/AccioKit/Models/CachedFrameworkProduct.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct CachedFrameworkProduct: Codable {
+    let swiftVersion: String
+    let libraryName: String
+    let commitHash: String
+    let platform: String
+
+    var cacheFileSubPath: String {
+        return "\(swiftVersion)/\(libraryName)/\(commitHash)/\(platform).zip"
+    }
+}

--- a/Sources/AccioKit/Models/FrameworkProduct.swift
+++ b/Sources/AccioKit/Models/FrameworkProduct.swift
@@ -3,15 +3,18 @@ import Foundation
 struct FrameworkProduct {
     let frameworkDirPath: String
     let symbolsFilePath: String
+    let commitHash: String
 
-    init(frameworkDirPath: String, symbolsFilePath: String) {
+    init(frameworkDirPath: String, symbolsFilePath: String, commitHash: String) {
         self.frameworkDirPath = frameworkDirPath
         self.symbolsFilePath = symbolsFilePath
+        self.commitHash = commitHash
     }
 
-    init(libraryName: String, platformName: String) {
+    init(libraryName: String, platformName: String, commitHash: String) {
         self.frameworkDirPath = Constants.temporaryFrameworksUrl.appendingPathComponent("\(platformName)/\(libraryName).framework").path
         self.symbolsFilePath = Constants.temporaryFrameworksUrl.appendingPathComponent("\(platformName)/\(libraryName).framework.dSYM").path
+        self.commitHash = commitHash
     }
 
     var frameworkDirUrl: URL {
@@ -24,6 +27,10 @@ struct FrameworkProduct {
 
     var libraryName: String {
         return frameworkDirUrl.lastPathComponent.replacingOccurrences(of: ".framework", with: "")
+    }
+
+    var platformName: String {
+        return frameworkDirUrl.pathComponents.suffix(2).first!
     }
 
     // This is a workaround for issues with frameworks that symlink to themselves (first found in RxSwift)

--- a/Sources/AccioKit/Services/CarthageBuilderService.swift
+++ b/Sources/AccioKit/Services/CarthageBuilderService.swift
@@ -39,7 +39,7 @@ final class CarthageBuilderService {
 
         try bash("/usr/local/bin/carthage build --project-directory '\(framework.projectDirectory)' --platform \(platform.rawValue) --no-skip-current --no-use-binaries")
 
-        let frameworkProduct = FrameworkProduct(libraryName: framework.libraryName, platformName: platform.rawValue)
+        let frameworkProduct = FrameworkProduct(libraryName: framework.libraryName, platformName: platform.rawValue, commitHash: framework.commitHash)
         let platformBuildDir = "\(framework.projectDirectory)/Carthage/Build/\(platform.carthageBuildFolderName)"
 
         try bash("mkdir -p '\(frameworkProduct.frameworkDirUrl.deletingLastPathComponent().path)'")

--- a/Sources/AccioKit/Services/FrameworkCachingService.swift
+++ b/Sources/AccioKit/Services/FrameworkCachingService.swift
@@ -44,11 +44,12 @@ final class FrameworkCachingService {
         }
     }
 
-    private func frameworkProduct(forCachedFileAt cachedFileUrl: URL) throws -> FrameworkProduct {
+    public func frameworkProduct(forCachedFileAt cachedFileUrl: URL) throws -> FrameworkProduct {
         let libraryName: String = cachedFileUrl.pathComponents.suffix(3).first!
         let platformName: String = cachedFileUrl.deletingPathExtension().lastPathComponent
+        let commitHash: String = cachedFileUrl.pathComponents.suffix(2).first!
 
-        let frameworkProduct = FrameworkProduct(libraryName: libraryName, platformName: platformName)
+        let frameworkProduct = FrameworkProduct(libraryName: libraryName, platformName: platformName, commitHash: commitHash)
 
         let subpath: String = cachedFileUrl.deletingPathExtension().pathComponents.suffix(3).joined(separator: "/")
         let unzippingUrl: URL = Constants.temporaryUncachingUrl.appendingPathComponent(subpath)

--- a/Sources/AccioKit/Services/FrameworkCachingService.swift
+++ b/Sources/AccioKit/Services/FrameworkCachingService.swift
@@ -54,15 +54,15 @@ final class FrameworkCachingService {
         let unzippingUrl: URL = Constants.temporaryUncachingUrl.appendingPathComponent(subpath)
 
         try bash("mkdir -p '\(unzippingUrl.path)'")
-        try run(bash: "unzip -n -q '\(cachedFileUrl.path)' -d '\(unzippingUrl.path)'")
+        try Task.run(bash: "unzip -n -q '\(cachedFileUrl.path)' -d '\(unzippingUrl.path)'")
 
         let unzippedFrameworkDirPath = unzippingUrl.appendingPathComponent("\(libraryName).framework").path
         let unzippedSymbolsFilePath = unzippingUrl.appendingPathComponent("\(libraryName).framework.dSYM").path
 
         try bash("mkdir -p '\(frameworkProduct.frameworkDirUrl.deletingLastPathComponent().path)'")
 
-        try run(bash: "cp -R '\(unzippedFrameworkDirPath)' '\(frameworkProduct.frameworkDirPath)'")
-        try run(bash: "cp -R '\(unzippedSymbolsFilePath)' '\(frameworkProduct.symbolsFilePath)'")
+        try Task.run(bash: "cp -R '\(unzippedFrameworkDirPath)' '\(frameworkProduct.frameworkDirPath)'")
+        try Task.run(bash: "cp -R '\(unzippedSymbolsFilePath)' '\(frameworkProduct.symbolsFilePath)'")
 
         try frameworkProduct.cleanupRecursiveFrameworkIfNeeded()
 
@@ -80,6 +80,6 @@ final class FrameworkCachingService {
         defer { FileManager.default.changeCurrentDirectoryPath(previousCurrentDirectoryPath) }
 
         FileManager.default.changeCurrentDirectoryPath(product.frameworkDirUrl.deletingLastPathComponent().path)
-        try run(bash: "zip -r -q -y '\(targetUrl.path)' '\(product.frameworkDirUrl.lastPathComponent)' '\(product.symbolsFileUrl.lastPathComponent)'")
+        try Task.run(bash: "zip -r -q -y '\(targetUrl.path)' '\(product.frameworkDirUrl.lastPathComponent)' '\(product.symbolsFileUrl.lastPathComponent)'")
     }
 }

--- a/Sources/AccioKit/Services/ResolvedManifestCachingService.swift
+++ b/Sources/AccioKit/Services/ResolvedManifestCachingService.swift
@@ -16,12 +16,18 @@ final class ResolvedManifestCachingService {
             let sharedCachePath = sharedCachePath,
             FileManager.default.fileExists(atPath: URL(fileURLWithPath: sharedCachePath).deletingLastPathComponent().path)
         {
+            let sharedCacheFileUrl = URL(fileURLWithPath: sharedCachePath).appendingPathComponent(subpath)
+            try bash("mkdir -p '\(sharedCacheFileUrl.deletingLastPathComponent().path)'")
+
             let data = try JSONEncoder().encode(cachedFrameworkProducts)
-            try data.write(to: URL(fileURLWithPath: sharedCachePath).appendingPathComponent(subpath))
+            try data.write(to: sharedCacheFileUrl)
             print("Saved resolved manifest in shared cache.", level: .info)
         } else {
+            let localCacheFileUrl = URL(fileURLWithPath: Constants.localCachePath).appendingPathComponent(subpath)
+            try bash("mkdir -p '\(localCacheFileUrl.deletingLastPathComponent().path)'")
+
             let data = try JSONEncoder().encode(cachedFrameworkProducts)
-            try data.write(to: URL(fileURLWithPath: Constants.localCachePath).appendingPathComponent(subpath))
+            try data.write(to: localCacheFileUrl)
             print("Saved resolved manifest in local cache.", level: .info)
         }
     }

--- a/Sources/AccioKit/Services/ResolvedManifestCachingService.swift
+++ b/Sources/AccioKit/Services/ResolvedManifestCachingService.swift
@@ -27,6 +27,8 @@ final class ResolvedManifestCachingService {
     }
 
     func cachedFrameworkProducts(forResolvedManifestAt url: URL) throws -> [CachedFrameworkProduct]? {
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+
         let resolvedManifestHash = try fileHash(at: url)
         let subpath = cacheFileSubPath(hash: resolvedManifestHash)
         let localCachedFileUrl = URL(fileURLWithPath: Constants.localCachePath).appendingPathComponent(subpath)

--- a/Sources/AccioKit/Services/ResolvedManifestCachingService.swift
+++ b/Sources/AccioKit/Services/ResolvedManifestCachingService.swift
@@ -1,0 +1,58 @@
+import Foundation
+import CryptoSwift
+
+final class ResolvedManifestCachingService {
+    private let sharedCachePath: String?
+
+    init(sharedCachePath: String?) {
+        self.sharedCachePath = sharedCachePath
+    }
+
+    func cacheResolvedManifest(at url: URL, with cachedFrameworkProducts: [CachedFrameworkProduct]) throws {
+        let resolvedManifestHash = try fileHash(at: url)
+        let subpath = cacheFileSubPath(hash: resolvedManifestHash)
+
+        if
+            let sharedCachePath = sharedCachePath,
+            FileManager.default.fileExists(atPath: URL(fileURLWithPath: sharedCachePath).deletingLastPathComponent().path)
+        {
+            let data = try JSONEncoder().encode(cachedFrameworkProducts)
+            try data.write(to: URL(fileURLWithPath: sharedCachePath).appendingPathComponent(subpath))
+            print("Saved resolved manifest in shared cache.", level: .info)
+        } else {
+            let data = try JSONEncoder().encode(cachedFrameworkProducts)
+            try data.write(to: URL(fileURLWithPath: Constants.localCachePath).appendingPathComponent(subpath))
+            print("Saved resolved manifest in local cache.", level: .info)
+        }
+    }
+
+    func cachedFrameworkProducts(forResolvedManifestAt url: URL) throws -> [CachedFrameworkProduct]? {
+        let resolvedManifestHash = try fileHash(at: url)
+        let subpath = cacheFileSubPath(hash: resolvedManifestHash)
+        let localCachedFileUrl = URL(fileURLWithPath: Constants.localCachePath).appendingPathComponent(subpath)
+
+        if FileManager.default.fileExists(atPath: localCachedFileUrl.path) {
+            print("Found cached resolved manifest results in local cache - trying to reuse cached build products.", level: .info)
+            return try JSONDecoder().decode([CachedFrameworkProduct].self, from: Data(contentsOf: localCachedFileUrl))
+        }
+
+        if let sharedCachePath = sharedCachePath {
+            let sharedCacheFileUrl = URL(fileURLWithPath: sharedCachePath).appendingPathComponent(subpath)
+
+            if FileManager.default.fileExists(atPath: sharedCacheFileUrl.path) {
+                print("Found cached resolved manifest results in shared cache - trying to reuse cached build products.", level: .info)
+                return try JSONDecoder().decode([CachedFrameworkProduct].self, from: Data(contentsOf: sharedCacheFileUrl))
+            }
+        }
+
+        return nil
+    }
+
+    private func fileHash(at url: URL) throws -> String {
+        return try Data(contentsOf: url).sha1().toHexString()
+    }
+
+    private func cacheFileSubPath(hash: String) -> String {
+        return "ResolvedManifests/\(hash).json"
+    }
+}

--- a/Tests/AccioKitTests/Services/FrameworkCachingServiceTests.swift
+++ b/Tests/AccioKitTests/Services/FrameworkCachingServiceTests.swift
@@ -7,7 +7,8 @@ class FrameworkCachingServiceTests: XCTestCase {
     private let testFramework = Framework(projectName: "TestProject", libraryName: "Example", projectDirectory: "", requiredFrameworks: [])
     private let testFrameworkProduct = FrameworkProduct(
         frameworkDirPath: FileManager.userCacheDirUrl.appendingPathComponent("AccioTestFrameworks/Example.framework").path,
-        symbolsFilePath: FileManager.userCacheDirUrl.appendingPathComponent("AccioTestFrameworks/Example.framework.dSYM").path
+        symbolsFilePath: FileManager.userCacheDirUrl.appendingPathComponent("AccioTestFrameworks/Example.framework.dSYM").path,
+        commitHash: "abc"
     )
 
     override func setUp() {

--- a/Tests/AccioKitTests/Services/ResolvedManifestCachingServiceTests.swift
+++ b/Tests/AccioKitTests/Services/ResolvedManifestCachingServiceTests.swift
@@ -1,0 +1,103 @@
+@testable import AccioKit
+import CryptoSwift
+import XCTest
+
+class ResolvedManifestCachingServiceTests: XCTestCase {
+    private let testResourcesDir: URL = FileManager.userCacheDirUrl.appendingPathComponent("AccioTestResources")
+
+    private var cachedResolvedManifestFileUrl: URL {
+        Constants.useTestPaths = true
+        let hash: String = resolvedManifestResource.contents.sha1()
+        return URL(fileURLWithPath: Constants.localCachePath).appendingPathComponent("ResolvedManifests/\(hash).json")
+    }
+
+    private var resolvedManifestResource: Resource {
+        return Resource(
+            url: testResourcesDir.appendingPathComponent("Package.resolved"),
+            contents: """
+                {
+                  "object": {
+                    "pins": [
+                      {
+                        "package": "HandySwift",
+                        "repositoryURL": "https://github.com/Flinesoft/HandySwift.git",
+                        "state": {
+                          "branch": null,
+                          "revision": "f736ec0ab264269cd4df91d6a685b4c78292cd76",
+                          "version": "2.8.0"
+                        }
+                      },
+                      {
+                        "package": "HandyUIKit",
+                        "repositoryURL": "https://github.com/Flinesoft/HandyUIKit.git",
+                        "state": {
+                          "branch": null,
+                          "revision": "9b56780efbc48dd372647729b9750b94b6c47561",
+                          "version": "1.9.1"
+                        }
+                      },
+                      {
+                        "package": "Imperio",
+                        "repositoryURL": "https://github.com/Flinesoft/Imperio.git",
+                        "state": {
+                          "branch": null,
+                          "revision": "238b9bc7de239d3e99a03ba94157d49a4ecd8b61",
+                          "version": "3.0.2"
+                        }
+                      },
+                      {
+                        "package": "MungoHealer",
+                        "repositoryURL": "https://github.com/JamitLabs/MungoHealer.git",
+                        "state": {
+                          "branch": null,
+                          "revision": "132e5e454298958f60ca6f1f34c733bc41f299e0",
+                          "version": "0.3.2"
+                        }
+                      },
+                      {
+                        "package": "SwiftyBeaver",
+                        "repositoryURL": "https://github.com/SwiftyBeaver/SwiftyBeaver.git",
+                        "state": {
+                          "branch": null,
+                          "revision": "ad66cc41c5d8acbd63d9dcdc9d3609f152e08ed1",
+                          "version": "1.7.0"
+                        }
+                      }
+                    ]
+                  },
+                  "version": 1
+                }
+
+                """
+        )
+    }
+
+    override func setUp() {
+        super.setUp()
+
+        Constants.useTestPaths = true
+
+        try! bash("rm -rf '\(testResourcesDir.path)'")
+        try! bash("mkdir '\(testResourcesDir.path)'")
+
+        try! bash("rm -rf '\(Constants.localCachePath)'")
+        try! bash("mkdir '\(Constants.localCachePath)'")
+    }
+
+    func testCacheResolvedManifest() {
+        let checkCachedResolvedManifestExistence: () -> Bool = {
+            return FileManager.default.fileExists(atPath: self.cachedResolvedManifestFileUrl.path)
+        }
+
+        resourcesLoaded([resolvedManifestResource]) {
+            XCTAssertFalse(checkCachedResolvedManifestExistence())
+
+            try! ResolvedManifestCachingService(sharedCachePath: nil).cacheResolvedManifest(
+                at: resolvedManifestResource.url,
+                with: []
+            )
+
+            XCTAssertTrue(checkCachedResolvedManifestExistence())
+        }
+    }
+}

--- a/Tests/AccioKitTests/Services/XcodeProjectIntegrationServiceTests.swift
+++ b/Tests/AccioKitTests/Services/XcodeProjectIntegrationServiceTests.swift
@@ -29,7 +29,8 @@ class XcodeProjectIntegrationServiceTests: XCTestCase {
         return testFrameworkNames.map {
             FrameworkProduct(
                 frameworkDirPath: testResourcesDir.appendingPathComponent(Constants.buildPath).appendingPathComponent("iOS/\($0).framework").path,
-                symbolsFilePath: testResourcesDir.appendingPathComponent(Constants.buildPath).appendingPathComponent("iOS/\($0).framework.dSYM").path
+                symbolsFilePath: testResourcesDir.appendingPathComponent(Constants.buildPath).appendingPathComponent("iOS/\($0).framework.dSYM").path,
+                commitHash: "abc"
             )
         }
     }
@@ -38,7 +39,8 @@ class XcodeProjectIntegrationServiceTests: XCTestCase {
         return testFrameworkNames.map {
             FrameworkProduct(
                 frameworkDirPath: testResourcesDir.appendingPathComponent(Constants.dependenciesPath).appendingPathComponent("iOS/\($0).framework").path,
-                symbolsFilePath: testResourcesDir.appendingPathComponent(Constants.dependenciesPath).appendingPathComponent("iOS/\($0).framework.dSYM").path
+                symbolsFilePath: testResourcesDir.appendingPathComponent(Constants.dependenciesPath).appendingPathComponent("iOS/\($0).framework.dSYM").path,
+                commitHash: "abc"
             )
         }
     }


### PR DESCRIPTION
This fixes the most useful part of #43.

TODO:
- [x] Save the resolved build products for a given `Package.resolved`
- [x] Skip checkout if no changes to `Package.resolved` & all build products cached
- [x] Write tests to ensure skipping works even with future changes

Please note that the main goal of this implementation is to reduce build times on CI since that's where changes to code without changes to the dependencies happens all the time and this will further improve build times by preventing the entire dependency resolution process, just reusing the cached build products. But of course, developers will profit from the enhancement, too.