### PR TITLE
Use current Swift version to fetch frameworks from cached manifest

### DIFF
--- a/Sources/AccioKit/Commands/Protocols/DependencyInstaller.swift
+++ b/Sources/AccioKit/Commands/Protocols/DependencyInstaller.swift
@@ -144,11 +144,11 @@ extension DependencyInstaller {
         }
 
         guard cachedFrameworkProductUrls.count == cachedFrameworkProducts.count else {
-            print("Not all required build products specified in resolved manifest are cached – unable to skip checkout/integration process ...")
+            print("Not all required build products specified in resolved manifest are cached – unable to skip checkout/integration process ...", level: .info)
             return false
         }
 
-        print("Found all required build products specified in resolved manifest in cache – skipping checkout & integration process ...")
+        print("Found all required build products specified in resolved manifest in cache – skipping checkout & integration process ...", level: .info)
 
         let frameworkProducts: [FrameworkProduct] = try cachedFrameworkProductUrls.map {
             return try FrameworkCachingService(sharedCachePath: sharedCachePath).frameworkProduct(forCachedFileAt: $0)

--- a/Sources/AccioKit/Commands/Protocols/DependencyInstaller.swift
+++ b/Sources/AccioKit/Commands/Protocols/DependencyInstaller.swift
@@ -103,7 +103,6 @@ extension DependencyInstaller {
             with: parsingResults.flatMap {
                 $0.frameworkProducts.map {
                     CachedFrameworkProduct(
-                        swiftVersion: swiftVersion,
                         libraryName: $0.libraryName,
                         commitHash: $0.commitHash,
                         platform: $0.platformName
@@ -126,14 +125,15 @@ extension DependencyInstaller {
         }
 
         let cachedFrameworkProductUrls: [URL] = cachedFrameworkProducts.compactMap { cachedFrameworkProduct in
-            let localCacheFileUrl = URL(fileURLWithPath: Constants.localCachePath).appendingPathComponent(cachedFrameworkProduct.cacheFileSubPath)
+            guard let cacheFileSubPath = try? cachedFrameworkProduct.getCacheFileSubPath() else { return nil }
 
+            let localCacheFileUrl = URL(fileURLWithPath: Constants.localCachePath).appendingPathComponent(cacheFileSubPath)
             if FileManager.default.fileExists(atPath: localCacheFileUrl.path) {
                 return localCacheFileUrl
             }
 
             if let sharedCachePath = sharedCachePath {
-                let sharedCacheFileUrl = URL(fileURLWithPath: sharedCachePath).appendingPathComponent(cachedFrameworkProduct.cacheFileSubPath)
+                let sharedCacheFileUrl = URL(fileURLWithPath: sharedCachePath).appendingPathComponent(cacheFileSubPath)
 
                 if FileManager.default.fileExists(atPath: sharedCacheFileUrl.path) {
                     return sharedCacheFileUrl
@@ -144,7 +144,7 @@ extension DependencyInstaller {
         }
 
         guard cachedFrameworkProductUrls.count == cachedFrameworkProducts.count else {
-            print("Not all required build products specified in resolved manifest are cached – unable to skip checkout/integration process ...", level: .info)
+            print("Not all required build products specified in resolved manifest are cached – unable to skip checkout / integration process ...", level: .info)
             return false
         }
 

--- a/Sources/AccioKit/Models/CachedFrameworkProduct.swift
+++ b/Sources/AccioKit/Models/CachedFrameworkProduct.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 struct CachedFrameworkProduct: Codable {
-    let swiftVersion: String
     let libraryName: String
     let commitHash: String
     let platform: String
 
-    var cacheFileSubPath: String {
+    func getCacheFileSubPath() throws -> String {
+        let swiftVersion = try SwiftVersionDetectorService.shared.getCurrentSwiftVersion()
         return "\(swiftVersion)/\(libraryName)/\(commitHash)/\(platform).zip"
     }
 }

--- a/Sources/AccioKit/Services/XcodeProjectIntegrationService.swift
+++ b/Sources/AccioKit/Services/XcodeProjectIntegrationService.swift
@@ -90,7 +90,7 @@ final class XcodeProjectIntegrationService {
             let dependenciesPath = "\(workingDirectory)/\(Constants.dependenciesPath)/\(platform)"
             let cachedFrameworkProducts = cachedFrameworkProducts.filter { $0.platformName == platform.rawValue }
 
-            print("Copying \(cachedFrameworkProducts.count) cached build products to dependencies folder for platform \(platform.rawValue).")
+            print("Copying \(cachedFrameworkProducts.count) cached build products to Dependencies folder for platform \(platform.rawValue).", level: .info)
             try copy(frameworkProducts: cachedFrameworkProducts, to: dependenciesPath)
         }
     }


### PR DESCRIPTION
Closes #63. Builds on #62 and should be rebased once that PR is merged.