### PR TITLE
Expect `Info.plist` in correct location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Removed
 - None.
 ### Fixed
-- None.
+- Adjusted the bundle version fallback to support both macOS and iOS frameworks
+  Issue: [#76](https://github.com/JamitLabs/Accio/issues/76) | PR: [#77](https://github.com/JamitLabs/Accio/pull/77) | Author: [Torsten Curdt](https://github.com/tcurdti)
 ### Security
 - None.
 

--- a/Sources/AccioKit/Models/Platform.swift
+++ b/Sources/AccioKit/Models/Platform.swift
@@ -66,4 +66,21 @@ enum Platform: String, CaseIterable {
             return [rawValue, "Apple Watch", "AppleWatch"]
         }
     }
+
+    var pathToPlist: String {
+        switch self {
+        case .iOS:
+            return ""
+
+        case .macOS:
+            return "Resources"
+
+        case .tvOS:
+            return ""
+
+        case .watchOS:
+            return ""
+        }
+    }
+
 }

--- a/Sources/AccioKit/Services/XcodeProjectIntegrationService.swift
+++ b/Sources/AccioKit/Services/XcodeProjectIntegrationService.swift
@@ -128,7 +128,7 @@ final class XcodeProjectIntegrationService {
 
             let frameworkProduct = FrameworkProduct(frameworkDirPath: frameworkDirPath, symbolsFilePath: symbolsFilePath, commitHash: frameworkProduct.commitHash)
             try frameworkProduct.cleanupRecursiveFrameworkIfNeeded()
-            try verifyBundleVersion(of: frameworkProduct)
+            try ensureBundleVersionExistence(of: frameworkProduct)
 
             copiedFrameworkProducts.append(frameworkProduct)
         }
@@ -243,7 +243,7 @@ final class XcodeProjectIntegrationService {
         try projectFile.write(path: Path(xcodeProjectPath), override: true)
     }
 
-    private func verifyBundleVersion(of product: FrameworkProduct) throws {
+    private func ensureBundleVersionExistence(of product: FrameworkProduct) throws {
         let plistURLs = [
             product.frameworkDirUrl.appendingPathComponent("Resources").appendingPathComponent("Info.plist"),
             product.frameworkDirUrl.appendingPathComponent("Info.plist"),

--- a/Sources/AccioKit/Services/XcodeProjectIntegrationService.swift
+++ b/Sources/AccioKit/Services/XcodeProjectIntegrationService.swift
@@ -244,7 +244,7 @@ final class XcodeProjectIntegrationService {
     }
 
     private func verifyBundleVersion(of product: FrameworkProduct) throws {
-        let plistURL = product.frameworkDirUrl.appendingPathComponent("Info.plist")
+        let plistURL = product.frameworkDirUrl.appendingPathComponent("Resources").appendingPathComponent("Info.plist")
         let data = try Data(contentsOf: plistURL)
         var format: PropertyListSerialization.PropertyListFormat = .binary
         var plist = try PropertyListSerialization.propertyList(from: data, options: [.mutableContainersAndLeaves], format: &format) as! [String: Any]

--- a/Tests/AccioKitTests/Services/XcodeProjectIntegrationServiceTests.swift
+++ b/Tests/AccioKitTests/Services/XcodeProjectIntegrationServiceTests.swift
@@ -54,9 +54,12 @@ class XcodeProjectIntegrationServiceTests: XCTestCase {
         clean()
     }
 
-    private func createInfoPlist(frameworkName: String, includeBundleVersion: Bool) {
-        let resourcesURL = testResourcesDir.appendingPathComponent(Constants.buildPath).appendingPathComponent("iOS/\(frameworkName).framework/Resources")
-         try! FileManager.default.createDirectory(atPath: resourcesURL.path, withIntermediateDirectories: true, attributes: nil)
+    private func createInfoPlist(platform: Platform, frameworkName: String, includeBundleVersion: Bool) {
+        let resourcesURL = testResourcesDir.appendingPathComponent(Constants.buildPath)
+            .appendingPathComponent(platform.rawValue)
+            .appendingPathComponent("\(frameworkName).framework")
+            .appendingPathComponent(platform.pathToPlist)
+        try! FileManager.default.createDirectory(atPath: resourcesURL.path, withIntermediateDirectories: true, attributes: nil)
         let plistURL = resourcesURL.appendingPathComponent("Info.plist")
         let plist = includeBundleVersion ? ["CFBundleVersion": "1"] : [:]
         let data = try! PropertyListSerialization.data(fromPropertyList: plist, format: .binary, options: 0)
@@ -68,6 +71,9 @@ class XcodeProjectIntegrationServiceTests: XCTestCase {
     }
 
     func testUpdateDependencies() {
+
+        let platform: Platform = .iOS
+
         let xcodeProjectIntegrationService = XcodeProjectIntegrationService(workingDirectory: testResourcesDir.path)
 
         for appTarget in [regularTarget, testTarget] {
@@ -90,21 +96,21 @@ class XcodeProjectIntegrationServiceTests: XCTestCase {
                 XCTAssert(!targetObject.buildPhases.contains { $0.type() == .runScript && ($0 as! PBXShellScriptBuildPhase).name == Constants.copyBuildScript })
 
                 testFrameworks.forEach { frameworkName, includeBundleVersion in
-                    createInfoPlist(frameworkName: frameworkName, includeBundleVersion: includeBundleVersion)
+                    createInfoPlist(platform:platform, frameworkName: frameworkName, includeBundleVersion: includeBundleVersion)
                 }
 
-                try! xcodeProjectIntegrationService.updateDependencies(of: appTarget, for: .iOS, with: frameworkProducts)
+                try! xcodeProjectIntegrationService.updateDependencies(of: appTarget, for: platform, with: frameworkProducts)
 
                 // test CFBundleVersion in Info.plist
                 frameworkProducts.forEach { product in
                     let frameworkPath = product.frameworkDirPath.replacingOccurrences(of: "/.accio/", with: "/Dependencies/")
-                    let plistURL = URL(fileURLWithPath: frameworkPath).appendingPathComponent("Resources").appendingPathComponent("Info.plist")
+                    let plistURL = URL(fileURLWithPath: frameworkPath).appendingPathComponent(platform.pathToPlist).appendingPathComponent("Info.plist")
                     let data = try! Data(contentsOf: plistURL)
                     var format: PropertyListSerialization.PropertyListFormat = .binary
                     var plist = try! PropertyListSerialization.propertyList(from: data, options: [.mutableContainersAndLeaves], format: &format) as! [String: Any]
 
-                    print(plistURL)
-                    print(plist)
+                    print("\(product.platformName) \(product.libraryName) \(plist)")
+
                     XCTAssertNotNil(plist["CFBundleVersion"])
                 }
 
@@ -129,7 +135,7 @@ class XcodeProjectIntegrationServiceTests: XCTestCase {
                     let accioBuildScript = targetObject.buildPhases.first { $0.type() == .runScript && ($0 as! PBXShellScriptBuildPhase).name == Constants.copyBuildScript } as! PBXShellScriptBuildPhase
 
                     XCTAssertEqual(accioBuildScript.inputPaths.count, testFrameworks.count)
-                    XCTAssertEqual(accioBuildScript.inputPaths, testFrameworks.map { "$(SRCROOT)/\(Constants.dependenciesPath)/iOS/\($0.name).framework" })
+                    XCTAssertEqual(accioBuildScript.inputPaths, testFrameworks.map { "$(SRCROOT)/\(Constants.dependenciesPath)/\(platform.rawValue)/\($0.name).framework" })
 
                 case .test, .appExtension:
                     let accioBuildScript = targetObject.buildPhases.first { $0.type() == .runScript && ($0 as! PBXShellScriptBuildPhase).name == Constants.copyBuildScript }

--- a/Tests/AccioKitTests/Services/XcodeProjectIntegrationServiceTests.swift
+++ b/Tests/AccioKitTests/Services/XcodeProjectIntegrationServiceTests.swift
@@ -55,7 +55,9 @@ class XcodeProjectIntegrationServiceTests: XCTestCase {
     }
 
     private func createInfoPlist(frameworkName: String, includeBundleVersion: Bool) {
-        let plistURL = testResourcesDir.appendingPathComponent(Constants.buildPath).appendingPathComponent("iOS/\(frameworkName).framework/Info.plist")
+        let resourcesURL = testResourcesDir.appendingPathComponent(Constants.buildPath).appendingPathComponent("iOS/\(frameworkName).framework/Resources")
+         try! FileManager.default.createDirectory(atPath: resourcesURL.path, withIntermediateDirectories: true, attributes: nil)
+        let plistURL = resourcesURL.appendingPathComponent("Info.plist")
         let plist = includeBundleVersion ? ["CFBundleVersion": "1"] : [:]
         let data = try! PropertyListSerialization.data(fromPropertyList: plist, format: .binary, options: 0)
         try! data.write(to: plistURL, options: .atomic)
@@ -96,7 +98,7 @@ class XcodeProjectIntegrationServiceTests: XCTestCase {
                 // test CFBundleVersion in Info.plist
                 frameworkProducts.forEach { product in
                     let frameworkPath = product.frameworkDirPath.replacingOccurrences(of: "/.accio/", with: "/Dependencies/")
-                    let plistURL = URL(fileURLWithPath: frameworkPath).appendingPathComponent("Info.plist")
+                    let plistURL = URL(fileURLWithPath: frameworkPath).appendingPathComponent("Resources").appendingPathComponent("Info.plist")
                     let data = try! Data(contentsOf: plistURL)
                     var format: PropertyListSerialization.PropertyListFormat = .binary
                     var plist = try! PropertyListSerialization.propertyList(from: data, options: [.mutableContainersAndLeaves], format: &format) as! [String: Any]


### PR DESCRIPTION
According to https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/FrameworkAnatomy.html the correct location for the `Info.plist` is
`FRAMEWORK.framework/Resources/Info.plist`. Yet the verification code was expecting it at `FRAMEWORK.framework/Info.plist` and failed the integration into the Xcode project.

The PR adjusts the location and `swift test` passes. It also works in my test project. This should fix #73 and #76