### PR TITLE
Add support for toolchain selection for frameworks build with carthage

### DIFF
--- a/Sources/AccioKit/Commands/InstallCommand.swift
+++ b/Sources/AccioKit/Commands/InstallCommand.swift
@@ -7,6 +7,7 @@ public class InstallCommand: Command {
     public let shortDescription: String = "Installs the already resolved dependencies"
 
     let sharedCachePath = Key<String>("-c", "--shared-cache-path", description: "Path used by multiple users for caching built products")
+    let toolchain = Key<String>("-t", "--toolchain", description: "Selection of a swift toolchain used for build")
 
     // MARK: - Initializers
     public init() {}
@@ -29,7 +30,8 @@ public class InstallCommand: Command {
         try buildFrameworksAndIntegrateWithXcode(
             manifest: manifest,
             dependencyGraph: dependencyGraph,
-            sharedCachePath: sharedCachePath.value ?? config.defaultSharedCachePath
+            sharedCachePath: sharedCachePath.value ?? config.defaultSharedCachePath,
+            toolchain: toolchain.value
         )
         print("Successfully installed dependencies.", level: .info)
     }

--- a/Sources/AccioKit/Commands/Protocols/DependencyInstaller.swift
+++ b/Sources/AccioKit/Commands/Protocols/DependencyInstaller.swift
@@ -8,7 +8,7 @@ enum DependencyInstallerError: Error {
 protocol DependencyInstaller {
     func loadManifest() throws -> Manifest
     func revertCheckoutChanges(workingDirectory: String) throws
-    func buildFrameworksAndIntegrateWithXcode(workingDirectory: String, manifest: Manifest, dependencyGraph: DependencyGraph, sharedCachePath: String?) throws
+    func buildFrameworksAndIntegrateWithXcode(workingDirectory: String, manifest: Manifest, dependencyGraph: DependencyGraph, sharedCachePath: String?, toolchain: String?) throws
     func loadRequiredFrameworksFromCache(workingDirectory: String, sharedCachePath: String?) throws -> Bool
 }
 
@@ -52,7 +52,8 @@ extension DependencyInstaller {
         workingDirectory: String = GlobalOptions.workingDirectory.value ?? FileManager.default.currentDirectoryPath,
         manifest: Manifest,
         dependencyGraph: DependencyGraph,
-        sharedCachePath: String?
+        sharedCachePath: String?,
+        toolchain: String? = nil
     ) throws {
         if FileManager.default.fileExists(atPath: Constants.temporaryFrameworksUrl.path) {
             try bash("rm -rf '\(Constants.temporaryFrameworksUrl.path)'")
@@ -84,7 +85,8 @@ extension DependencyInstaller {
                 appTarget: appTarget,
                 dependencyGraph: dependencyGraph,
                 platform: platform,
-                swiftVersion: swiftVersion
+                swiftVersion: swiftVersion,
+                toolchain: toolchain
             )
             return ParsingResult(target: appTarget, platform: platform, frameworkProducts: frameworkProducts)
         }

--- a/Sources/AccioKit/Commands/UpdateCommand.swift
+++ b/Sources/AccioKit/Commands/UpdateCommand.swift
@@ -7,6 +7,7 @@ public class UpdateCommand: Command {
     public let shortDescription: String = "Updates the dependencies"
 
     let sharedCachePath = Key<String>("-c", "--shared-cache-path", description: "Path used by multiple users for caching built products")
+    let toolchain = Key<String>("-t", "--toolchain", description: "Selection of a swift toolchain used for build")
 
     // MARK: - Initializers
     public init() {}
@@ -23,7 +24,8 @@ public class UpdateCommand: Command {
         try buildFrameworksAndIntegrateWithXcode(
             manifest: manifest,
             dependencyGraph: dependencyGraph,
-            sharedCachePath: sharedCachePath.value ?? config.defaultSharedCachePath
+            sharedCachePath: sharedCachePath.value ?? config.defaultSharedCachePath,
+            toolchain: toolchain.value
         )
         print("Successfully updated dependencies.", level: .info)
     }

--- a/Sources/AccioKit/Services/CachedBuilderService.swift
+++ b/Sources/AccioKit/Services/CachedBuilderService.swift
@@ -31,7 +31,8 @@ final class CachedBuilderService {
         appTarget: AppTarget,
         dependencyGraph: DependencyGraph,
         platform: Platform,
-        swiftVersion: String
+        swiftVersion: String,
+        toolchain: String? = nil
     ) throws -> [FrameworkProduct] {
         var frameworkProducts: [FrameworkProduct] = []
 
@@ -67,7 +68,8 @@ final class CachedBuilderService {
                         framework: framework,
                         platform: platform,
                         swiftVersion: swiftVersion,
-                        alreadyBuiltFrameworkProducts: frameworkProducts
+                        alreadyBuiltFrameworkProducts: frameworkProducts,
+                        toolchain: toolchain
                     )
                 }
 
@@ -80,7 +82,7 @@ final class CachedBuilderService {
                 {
                     // If detectSwiftVersion doesn't work (e. g. happening for RxAtomic because of missing Swift header file),
                     // fallback to just retrieving current swift version via bash command.
-                    guard frameworkSwiftVersion == swiftVersion else {
+                    guard frameworkSwiftVersion == swiftVersion || toolchain != nil else {
                         throw CachedBuilderServiceError.swiftVersionChanged
                     }
                 } else {


### PR DESCRIPTION
Swift versions prior to 5.1 do not support module stability and require the frameworks to be build with the same swift version as the current development environment. There is a command line option in carthage called `--toolchain` which can be used to change the toolchain used to build the frameworks. This pull request adds the support into accio to pass that parameter to carthage while building.